### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Stripe Clojure library provides convenient access to the Stripe API from app
 In `project.clj` file, add the dependency to `:dependencies`
 
 ```clojure
-[io.github.yonureker/stripe-clojure "0.1.2"]
+[io.github.yonureker/stripe-clojure "0.1.3"]
 ```
 
 #### deps.edn
@@ -24,7 +24,7 @@ In `project.clj` file, add the dependency to `:dependencies`
 If you are using `deps.edn` file, add the dependency to `:deps `
 
 ```clojure
-io.github.yonureker/stripe-clojure {:mvn/version "0.1.2"}
+io.github.yonureker/stripe-clojure {:mvn/version "0.1.3"}
 ```
 
 ## Usage

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.yonureker/stripe-clojure "0.1.2"
+(defproject io.github.yonureker/stripe-clojure "0.1.3"
   :description "Clojure library for Stripe API"
   :url "http://github.com/yonureker/stripe-clojure"
   :license {:name "MIT License"

--- a/src/stripe_clojure/config.clj
+++ b/src/stripe_clojure/config.clj
@@ -3,7 +3,7 @@
 
 ;; Default Configuration
 (def api-keys
-  {:test "test_api_key"})
+  {:test (or (System/getenv "STRIPE_TEST_API_KEY") "test_api_key")})
 
 ;; API Endpoints
 (def stripe-api-namespace "v1")

--- a/src/stripe_clojure/http/retry.clj
+++ b/src/stripe_clojure/http/retry.clj
@@ -4,7 +4,7 @@
   (let [base-delay 250
         max-delay 20000
         exponential-delay (* base-delay (Math/pow 2 attempt))
-        jitter (rand-int (/ exponential-delay 2))
+        jitter (rand-int (int (/ exponential-delay 2)))
         final-delay (min (+ exponential-delay jitter) max-delay)]
     (Thread/sleep final-delay)))
 


### PR DESCRIPTION
* Updated README
* Enable testing with test API key
* Fix exponential backoff issue