### PR TITLE
Remove support for list and retrieve upcoming

### DIFF
--- a/src/stripe_clojure/invoices.clj
+++ b/src/stripe_clojure/invoices.clj
@@ -47,14 +47,6 @@
   ([stripe-client invoice-id opts]
    (request stripe-client :get (str stripe-invoices-endpoint "/" invoice-id) {} opts)))
 
-(defn retrieve-upcoming
-  "Retrieves the upcoming invoice.
-   \nStripe API docs: https://stripe.com/docs/api/invoices/upcoming"
-  ([stripe-client params]
-   (retrieve-upcoming stripe-client params {}))
-  ([stripe-client params opts]
-   (request stripe-client :get (str stripe-invoices-endpoint "/upcoming") params opts)))
-
 (defn list-invoices
   "Returns a list of invoices.
    Stripe API docs: https://stripe.com/docs/api/invoices/list
@@ -163,17 +155,6 @@
   ([stripe-client invoice-id params opts]
    (request stripe-client :get
                 (str stripe-invoices-endpoint "/" invoice-id "/lines")
-                params
-                opts)))
-
-(defn list-upcoming-line-items
-  "Lists all line items for an upcoming invoice.
-   \nStripe API docs: https://stripe.com/docs/api/invoices/upcoming_lines"
-  ([stripe-client params]
-   (list-upcoming-line-items stripe-client params {}))
-  ([stripe-client params opts]
-   (request stripe-client :get
-                (str stripe-invoices-endpoint "/upcoming/lines")
                 params
                 opts)))
 

--- a/test/stripe_clojure/mock/invoices_test.clj
+++ b/test/stripe_clojure/mock/invoices_test.clj
@@ -40,13 +40,6 @@
       (is (= invoice-id (:id retrieved)) "Retrieved invoice should match created one")
       (is (= "invoice" (:object retrieved))))))
 
-(deftest retrieve-upcoming-test
-  (testing "retrieve-upcoming returns a valid upcoming invoice"
-    (let [dummy-customer "cus_mock_123"
-          upcoming (invoices/retrieve-upcoming stripe-mock-client {:customer dummy-customer})]
-      (is (map? upcoming))
-      (is (= "invoice" (:object upcoming))))))
-
 (deftest list-invoices-test
   (testing "list-invoices returns a list response"
     (let [resp (invoices/list-invoices stripe-mock-client {:limit 1})]
@@ -122,12 +115,6 @@
   (testing "list-line-items returns a list of line items"
     (let [dummy-invoice-id "inv_mock_123"
           resp (invoices/list-line-items stripe-mock-client dummy-invoice-id {:limit 1})]
-      (is (map? resp))
-      (is (vector? (:data resp))))))
-
-(deftest list-upcoming-line-items-test
-  (testing "list-upcoming-line-items returns upcoming line items"
-    (let [resp (invoices/list-upcoming-line-items stripe-mock-client {:customer "cus_mock_123" :limit 1})]
       (is (map? resp))
       (is (vector? (:data resp))))))
 


### PR DESCRIPTION
Remove support for listUpcomingLines and retrieveUpcoming methods on resource Invoice