### PR TITLE
Remove support for create and list usage record summaries

### DIFF
--- a/src/stripe_clojure/subscription_items.clj
+++ b/src/stripe_clojure/subscription_items.clj
@@ -54,27 +54,3 @@
             (str stripe-subscription-items-endpoint "/" subscription-item-id)
             nil
             opts)))
-
-(defn create-usage-record
-  "Creates a usage record for a specified subscription item.
-   \nStripe API docs: https://stripe.com/docs/api/usage_records/create"
-  ([stripe-client subscription-item-id params]
-   (create-usage-record stripe-client subscription-item-id params {}))
-  ([stripe-client subscription-item-id params opts]
-   (request stripe-client :post
-            (str stripe-subscription-items-endpoint "/" subscription-item-id "/usage_records")
-            params
-            opts)))
-
-(defn list-usage-record-summaries
-  "Lists all usage record summaries for a specified subscription item.
-   \nStripe API docs: https://stripe.com/docs/api/usage_records/subscription_item_summary_list"
-  ([stripe-client subscription-item-id]
-   (list-usage-record-summaries stripe-client subscription-item-id {}))
-  ([stripe-client subscription-item-id params]
-   (list-usage-record-summaries stripe-client subscription-item-id params {}))
-  ([stripe-client subscription-item-id params opts]
-   (request stripe-client :get
-            (str stripe-subscription-items-endpoint "/" subscription-item-id "/usage_record_summaries")
-            params
-            opts)))

--- a/test/stripe_clojure/mock/subscription_items_test.clj
+++ b/test/stripe_clojure/mock/subscription_items_test.clj
@@ -50,23 +50,3 @@
       (is (= "subscription_item" (:object response)))
       (is (string? (:id response)))
       (is (true? (:deleted response))))))
-
-(deftest create-usage-record-test
-  (testing "Create usage record"
-    (let [params {:quantity 100}
-          response (subitems/create-usage-record stripe-mock-client "si_mock" params)]
-      (is (map? response))
-      (is (= "usage_record" (:object response)))
-      (is (string? (:id response)))
-      (is (= 100 (:quantity response))))))
-
-(deftest list-usage-record-summaries-test
-  (testing "List usage record summaries"
-    (let [response (subitems/list-usage-record-summaries stripe-mock-client "si_mock" {:limit 2})]
-      (is (map? response))
-      (is (= "list" (:object response)))
-      (is (vector? (:data response)))
-      (doseq [summary (:data response)]
-        (is (map? summary))
-        (is (= "usage_record_summary" (:object summary)))
-        (is (string? (:id summary))))))) 


### PR DESCRIPTION
Remove support for `createUsageRecord` and `listUsageRecordSummaries` methods on resource SubscriptionItems