### PR TITLE
2.3.0 improvements — API version bump, new endpoints, and performance fixes

### DIFF
--- a/src/stripe_clojure/config.clj
+++ b/src/stripe_clojure/config.clj
@@ -64,6 +64,7 @@
    :issuing-disputes (str "/" stripe-api-namespace "/issuing/disputes")
    :issuing-personalization-designs (str "/" stripe-api-namespace "/issuing/personalization_designs")
    :issuing-physical-bundles (str "/" stripe-api-namespace "/issuing/physical_bundles")
+   :issuing-settlements (str "/" stripe-api-namespace "/issuing/settlements")
    :issuing-tokens (str "/" stripe-api-namespace "/issuing/tokens")
    :issuing-transactions (str "/" stripe-api-namespace "/issuing/transactions")
    :mandates (str "/" stripe-api-namespace "/mandates")
@@ -81,6 +82,7 @@
    :products (str "/" stripe-api-namespace "/products")
    :quotes (str "/" stripe-api-namespace "/quotes")
    :radar-early-fraud-warnings (str "/" stripe-api-namespace "/radar/early_fraud_warnings")
+   :radar-payment-evaluations (str "/" stripe-api-namespace "/radar/payment_evaluations")
    :radar-value-list-items (str "/" stripe-api-namespace "/radar/value_list_items")
    :radar-value-lists (str "/" stripe-api-namespace "/radar/value_lists")
    :refunds (str "/" stripe-api-namespace "/refunds")
@@ -90,6 +92,7 @@
    :setup-attempts (str "/" stripe-api-namespace "/setup_attempts")
    :setup-intents (str "/" stripe-api-namespace "/setup_intents")
    :shipping-rates (str "/" stripe-api-namespace "/shipping_rates")
+   :sigma-saved-queries (str "/" stripe-api-namespace "/sigma/saved_queries")
    :sigma-scheduled-query-runs (str "/" stripe-api-namespace "/sigma/scheduled_query_runs")
    :sources (str "/" stripe-api-namespace "/sources")
    :subscriptions (str "/" stripe-api-namespace "/subscriptions")
@@ -108,6 +111,7 @@
    :terminal-locations (str "/" stripe-api-namespace "/terminal/locations")
    :terminal-onboarding-links (str "/" stripe-api-namespace "/terminal/onboarding_links")
    :terminal-readers (str "/" stripe-api-namespace "/terminal/readers")
+   :terminal-refunds (str "/" stripe-api-namespace "/terminal/refunds")
    :test-helpers-customers (str "/" stripe-api-namespace "/test_helpers/customers")
    :test-helpers-confirmation-tokens (str "/" stripe-api-namespace "/test_helpers/confirmation_tokens")
    :treasury-credit-reversals (str "/" stripe-api-namespace "/treasury/credit_reversals")
@@ -136,7 +140,9 @@
    - Pagination: URL-based instead of cursor-based
    - Field expansion: 'include' parameter instead of 'expand'
    - Idempotency: 30-day window instead of 24-hour"
-  {:v2-core-accounts (str "/" stripe-v2-api-namespace "/core/accounts")
+  {:v2-core-account-links (str "/" stripe-v2-api-namespace "/core/account_links")
+   :v2-core-account-tokens (str "/" stripe-v2-api-namespace "/core/account_tokens")
+   :v2-core-accounts (str "/" stripe-v2-api-namespace "/core/accounts")
    :v2-core-events (str "/" stripe-v2-api-namespace "/core/events")
    :v2-core-event-destinations (str "/" stripe-v2-api-namespace "/core/event_destinations")
    :v2-billing-meter-event-session (str "/" stripe-v2-api-namespace "/billing/meter_event_session")
@@ -155,7 +161,7 @@
             suffix (subs api-key (- (count api-key) 4))]
         (str prefix "..." suffix)))))
 
-(def base-api-version "2026-01-28.clover")
+(def base-api-version "2026-04-22.dahlia")
 
 (def default-client-config
   {:protocol "https"

--- a/src/stripe_clojure/http/request.clj
+++ b/src/stripe_clojure/http/request.clj
@@ -156,8 +156,9 @@
 (defn make-request
   "Makes an HTTP request to the Stripe API."
   [method url params opts config]
-  (validate-request-opts! opts)
-  (let [{:keys [full-url options headers timeout is-v2 is-get
+  (let [opts (or opts {})
+        _ (validate-request-opts! opts)
+        {:keys [full-url options headers timeout is-v2 is-get
                 detected-version expand-params merged]} (prepare-request-context method url params opts config)
         {:keys [max-network-retries full-response? listeners kebabify-keys? throttler http-client]} merged
         request-fn (retry/with-retry #(send-stripe-api-request method full-url options) max-network-retries)

--- a/src/stripe_clojure/http/request.clj
+++ b/src/stripe_clojure/http/request.clj
@@ -36,10 +36,13 @@
 (defn generate-idempotency-key ^String []
   (str (java.util.UUID/randomUUID)))
 
+(def ^:private valid-request-opts? (m/validator schema/RequestOpts))
+
 (defn- validate-request-opts! [opts]
-  (when-let [explanation (m/explain schema/RequestOpts opts)]
-    (throw (ex-info (str "Invalid request options: " (pr-str (me/humanize explanation)))
-                    {:errors (me/humanize explanation) :provided-options opts}))))
+  (when-not (valid-request-opts? opts)
+    (let [humanized (me/humanize (m/explain schema/RequestOpts opts))]
+      (throw (ex-info (str "Invalid request options: " (pr-str humanized))
+                      {:errors humanized :provided-options opts})))))
 
 (defn- validate-url! [^String full-url base-url endpoint]
   (when-not (re-matches url-pattern full-url)
@@ -192,12 +195,13 @@
                                result)
                              result)]
           (when (and listeners (seq @listeners))
-            (events/emit-event listeners :response
-                               {:method method :url url :api-version (:api-version merged)
-                                :request-start-time start-time :account (:stripe-account merged)}
-                               {:request-end-time (System/currentTimeMillis)
-                                :elapsed (- (System/currentTimeMillis) start-time)
-                                :status (:status raw-result)
-                                :request-id (get-in raw-result [:headers "request-id"])}
-                               kebabify-keys?))
+            (let [end-time (System/currentTimeMillis)]
+              (events/emit-event listeners :response
+                                 {:method method :url url :api-version (:api-version merged)
+                                  :request-start-time start-time :account (:stripe-account merged)}
+                                 {:request-end-time end-time
+                                  :elapsed (- end-time start-time)
+                                  :status (:status raw-result)
+                                  :request-id (get-in raw-result [:headers "request-id"])}
+                                 kebabify-keys?)))
           final-result)))))

--- a/src/stripe_clojure/issuing/settlements.clj
+++ b/src/stripe_clojure/issuing/settlements.clj
@@ -1,0 +1,27 @@
+(ns stripe-clojure.issuing.settlements
+  (:require [stripe-clojure.http.client :refer [request]]
+            [stripe-clojure.config :as config]))
+
+(def stripe-issuing-settlements-endpoint (config/stripe-endpoints :issuing-settlements))
+
+(defn retrieve-settlement
+  "Retrieves an issuing settlement.
+   \nStripe API docs: https://stripe.com/docs/api/issuing/settlements/retrieve"
+  ([stripe-client settlement-id]
+   (retrieve-settlement stripe-client settlement-id {}))
+  ([stripe-client settlement-id opts]
+   (request stripe-client :get
+                (str stripe-issuing-settlements-endpoint "/" settlement-id)
+                {}
+                opts)))
+
+(defn update-settlement
+  "Updates an issuing settlement.
+   \nStripe API docs: https://stripe.com/docs/api/issuing/settlements/update"
+  ([stripe-client settlement-id params]
+   (update-settlement stripe-client settlement-id params {}))
+  ([stripe-client settlement-id params opts]
+   (request stripe-client :post
+                (str stripe-issuing-settlements-endpoint "/" settlement-id)
+                params
+                opts)))

--- a/src/stripe_clojure/radar/payment_evaluations.clj
+++ b/src/stripe_clojure/radar/payment_evaluations.clj
@@ -1,0 +1,13 @@
+(ns stripe-clojure.radar.payment-evaluations
+  (:require [stripe-clojure.http.client :refer [request]]
+            [stripe-clojure.config :as config]))
+
+(def stripe-radar-payment-evaluations-endpoint (config/stripe-endpoints :radar-payment-evaluations))
+
+(defn create-payment-evaluation
+  "Creates a payment evaluation.
+   \nStripe API docs: https://stripe.com/docs/api/radar/payment_evaluations/create"
+  ([stripe-client params]
+   (create-payment-evaluation stripe-client params {}))
+  ([stripe-client params opts]
+   (request stripe-client :post stripe-radar-payment-evaluations-endpoint params opts)))

--- a/src/stripe_clojure/sigma/saved_queries.clj
+++ b/src/stripe_clojure/sigma/saved_queries.clj
@@ -1,0 +1,16 @@
+(ns stripe-clojure.sigma.saved-queries
+  (:require [stripe-clojure.http.client :refer [request]]
+            [stripe-clojure.config :as config]))
+
+(def stripe-sigma-saved-queries-endpoint (config/stripe-endpoints :sigma-saved-queries))
+
+(defn update-saved-query
+  "Updates a sigma saved query.
+   \nStripe API docs: https://stripe.com/docs/api/sigma/saved_queries/update"
+  ([stripe-client saved-query-id params]
+   (update-saved-query stripe-client saved-query-id params {}))
+  ([stripe-client saved-query-id params opts]
+   (request stripe-client :post
+                (str stripe-sigma-saved-queries-endpoint "/" saved-query-id)
+                params
+                opts)))

--- a/src/stripe_clojure/terminal/refunds.clj
+++ b/src/stripe_clojure/terminal/refunds.clj
@@ -1,0 +1,13 @@
+(ns stripe-clojure.terminal.refunds
+  (:require [stripe-clojure.http.client :refer [request]]
+            [stripe-clojure.config :as config]))
+
+(def stripe-terminal-refunds-endpoint (config/stripe-endpoints :terminal-refunds))
+
+(defn create-refund
+  "Creates a terminal refund.
+   \nStripe API docs: https://stripe.com/docs/api/terminal/refunds/create"
+  ([stripe-client params]
+   (create-refund stripe-client params {}))
+  ([stripe-client params opts]
+   (request stripe-client :post stripe-terminal-refunds-endpoint params opts)))

--- a/src/stripe_clojure/v2/core/account_links.clj
+++ b/src/stripe_clojure/v2/core/account_links.clj
@@ -1,0 +1,35 @@
+(ns stripe-clojure.v2.core.account-links
+  "V2 Core Account Links API.
+
+   Account Links create single-use URLs that an account can use to access
+   a Stripe-hosted flow for collecting or updating required information.
+
+   Stripe docs: https://docs.stripe.com/api/v2/core/account_links"
+  (:require [stripe-clojure.http.client :refer [request]]
+            [stripe-clojure.config :as config]))
+
+(def ^:private endpoint (:v2-core-account-links config/stripe-v2-endpoints))
+
+(defn create-account-link
+  "Creates an AccountLink object that includes a single-use URL.
+
+   Docs: https://docs.stripe.com/api/v2/core/account_links/create
+
+   Parameters:
+   - stripe-client: The Stripe client instance
+   - params: The account link parameters
+     - :account (required) - The ID of the account to create a link for
+     - :use_case (required) - The use case for the account link
+   - opts: Optional request options
+
+   Returns:
+   The created account link object.
+
+   Example:
+   (create-account-link client
+     {:account \"acct_xxx\"
+      :use_case {:type \"account_onboarding\"}})"
+  ([stripe-client params]
+   (create-account-link stripe-client params {}))
+  ([stripe-client params opts]
+   (request stripe-client :post endpoint params opts)))

--- a/src/stripe_clojure/v2/core/account_tokens.clj
+++ b/src/stripe_clojure/v2/core/account_tokens.clj
@@ -1,0 +1,57 @@
+(ns stripe-clojure.v2.core.account-tokens
+  "V2 Core Account Tokens API.
+
+   Account Tokens tokenize sensitive account information and can be used
+   when creating or updating an Account.
+
+   Stripe docs: https://docs.stripe.com/api/v2/core/account_tokens"
+  (:require [stripe-clojure.http.client :refer [request]]
+            [stripe-clojure.config :as config]))
+
+(def ^:private endpoint (:v2-core-account-tokens config/stripe-v2-endpoints))
+
+(defn create-account-token
+  "Creates an Account Token.
+
+   Docs: https://docs.stripe.com/api/v2/core/account_tokens/create
+
+   Parameters:
+   - stripe-client: The Stripe client instance
+   - params: The account token parameters
+     - :contact_email - The contact email for the account
+     - :contact_phone - The contact phone for the account
+     - :display_name - The display name for the account
+     - :identity - Identity information for the account
+   - opts: Optional request options
+
+   Returns:
+   The created account token object.
+
+   Example:
+   (create-account-token client
+     {:display_name \"My Business\"
+      :contact_email \"business@example.com\"})"
+  ([stripe-client params]
+   (create-account-token stripe-client params {}))
+  ([stripe-client params opts]
+   (request stripe-client :post endpoint params opts)))
+
+(defn retrieve-account-token
+  "Retrieves an Account Token by ID.
+
+   Docs: https://docs.stripe.com/api/v2/core/account_tokens/retrieve
+
+   Parameters:
+   - stripe-client: The Stripe client instance
+   - token-id: The ID of the account token
+   - opts: Optional request options
+
+   Returns:
+   The account token object.
+
+   Example:
+   (retrieve-account-token client \"actok_xxx\")"
+  ([stripe-client token-id]
+   (retrieve-account-token stripe-client token-id {}))
+  ([stripe-client token-id opts]
+   (request stripe-client :get (str endpoint "/" token-id) {} opts)))

--- a/test/stripe_clojure/mock/issuing/settlements_test.clj
+++ b/test/stripe_clojure/mock/issuing/settlements_test.clj
@@ -1,0 +1,19 @@
+(ns stripe-clojure.mock.issuing.settlements-test
+  (:require [stripe-clojure.test-util :refer [stripe-mock-client]]
+            [clojure.test :refer [deftest is testing]]
+            [stripe-clojure.issuing.settlements :as settlements]))
+
+(deftest retrieve-settlement-test
+  (testing "Retrieve an issuing settlement"
+    (let [response (settlements/retrieve-settlement stripe-mock-client "ist_mock")]
+      (is (map? response))
+      (is (= "issuing.settlement" (:object response)))
+      (is (string? (:id response))))))
+
+(deftest update-settlement-test
+  (testing "Update an issuing settlement"
+    (let [params {:metadata {:key "value"}}
+          response (settlements/update-settlement stripe-mock-client "ist_mock" params)]
+      (is (map? response))
+      (is (= "issuing.settlement" (:object response)))
+      (is (string? (:id response))))))

--- a/test/stripe_clojure/mock/sigma/saved_queries_test.clj
+++ b/test/stripe_clojure/mock/sigma/saved_queries_test.clj
@@ -1,0 +1,12 @@
+(ns stripe-clojure.mock.sigma.saved-queries-test
+  (:require [stripe-clojure.test-util :refer [stripe-mock-client]]
+            [clojure.test :refer [deftest is testing]]
+            [stripe-clojure.sigma.saved-queries :as sq]))
+
+(deftest update-saved-query-test
+  (testing "Update a sigma saved query"
+    (let [params {:name "Updated Query" :sql "SELECT * FROM charges"}
+          response (sq/update-saved-query stripe-mock-client "sqsav_mock" params)]
+      (is (map? response))
+      (is (= "sigma.sigma_api_query" (:object response)))
+      (is (string? (:id response))))))

--- a/test/stripe_clojure/unit/radar/payment_evaluations_test.clj
+++ b/test/stripe_clojure/unit/radar/payment_evaluations_test.clj
@@ -1,0 +1,40 @@
+(ns stripe-clojure.unit.radar.payment-evaluations-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [stripe-clojure.http.client :as client]
+            [stripe-clojure.radar.payment-evaluations :as pe]
+            [stripe-clojure.config :as config]))
+
+(deftest endpoint-configuration-test
+  (testing "endpoint is correctly configured"
+    (is (= "/v1/radar/payment_evaluations"
+           (:radar-payment-evaluations config/stripe-endpoints)))))
+
+(deftest create-payment-evaluation-test
+  (testing "create-payment-evaluation calls request with correct params"
+    (let [captured (atom nil)
+          params {:customer_details {:customer "cus_123"}
+                  :payment_details {:payment_method "pm_123"}}]
+      (with-redefs [client/request
+                    (fn [_client m e p o]
+                      (reset! captured {:method m :endpoint e :params p :opts o})
+                      {:id "mock_result"})]
+        (pe/create-payment-evaluation :mock-client params))
+      (is (= :post (:method @captured)))
+      (is (= "/v1/radar/payment_evaluations" (:endpoint @captured)))
+      (is (= params (:params @captured)))
+      (is (= {} (:opts @captured))))))
+
+(deftest create-payment-evaluation-with-opts-test
+  (testing "create-payment-evaluation forwards opts"
+    (let [captured (atom nil)
+          params {:customer_details {:customer "cus_123"}
+                  :payment_details {:payment_method "pm_123"}}]
+      (with-redefs [client/request
+                    (fn [_client m e p o]
+                      (reset! captured {:method m :endpoint e :params p :opts o})
+                      {:id "mock_result"})]
+        (pe/create-payment-evaluation :mock-client params {:idempotency-key "key_1"}))
+      (is (= :post (:method @captured)))
+      (is (= "/v1/radar/payment_evaluations" (:endpoint @captured)))
+      (is (= params (:params @captured)))
+      (is (= {:idempotency-key "key_1"} (:opts @captured))))))

--- a/test/stripe_clojure/unit/terminal/refunds_test.clj
+++ b/test/stripe_clojure/unit/terminal/refunds_test.clj
@@ -1,0 +1,38 @@
+(ns stripe-clojure.unit.terminal.refunds-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [stripe-clojure.http.client :as client]
+            [stripe-clojure.terminal.refunds :as refunds]
+            [stripe-clojure.config :as config]))
+
+(deftest endpoint-configuration-test
+  (testing "endpoint is correctly configured"
+    (is (= "/v1/terminal/refunds"
+           (:terminal-refunds config/stripe-endpoints)))))
+
+(deftest create-refund-test
+  (testing "create-refund calls request with correct params"
+    (let [captured (atom nil)
+          params {:payment_intent "pi_123" :amount 500}]
+      (with-redefs [client/request
+                    (fn [_client m e p o]
+                      (reset! captured {:method m :endpoint e :params p :opts o})
+                      {:id "mock_result"})]
+        (refunds/create-refund :mock-client params))
+      (is (= :post (:method @captured)))
+      (is (= "/v1/terminal/refunds" (:endpoint @captured)))
+      (is (= params (:params @captured)))
+      (is (= {} (:opts @captured))))))
+
+(deftest create-refund-with-opts-test
+  (testing "create-refund forwards opts"
+    (let [captured (atom nil)
+          params {:payment_intent "pi_123" :amount 500}]
+      (with-redefs [client/request
+                    (fn [_client m e p o]
+                      (reset! captured {:method m :endpoint e :params p :opts o})
+                      {:id "mock_result"})]
+        (refunds/create-refund :mock-client params {:idempotency-key "key_1"}))
+      (is (= :post (:method @captured)))
+      (is (= "/v1/terminal/refunds" (:endpoint @captured)))
+      (is (= params (:params @captured)))
+      (is (= {:idempotency-key "key_1"} (:opts @captured))))))

--- a/test/stripe_clojure/unit/v2/core/account_links_test.clj
+++ b/test/stripe_clojure/unit/v2/core/account_links_test.clj
@@ -1,0 +1,38 @@
+(ns stripe-clojure.unit.v2.core.account-links-test
+  (:require [clojure.test :refer [deftest testing]]
+            [stripe-clojure.unit.test-helpers :as h]
+            [stripe-clojure.v2.core.account-links :as v2-account-links]
+            [stripe-clojure.config :as config]))
+
+(deftest endpoint-configuration-test
+  (h/check-endpoint config/stripe-v2-endpoints :v2-core-account-links "/v2/core/account_links"))
+
+(deftest function-existence-test
+  (testing "all account link functions exist"
+    (h/check-functions-exist
+     [#'v2-account-links/create-account-link])))
+
+(deftest function-arities-test
+  (h/check-function-arities
+   [[#'v2-account-links/create-account-link #{2 3}]]))
+
+(deftest docstrings-test
+  (h/check-docstrings
+   [[#'v2-account-links/create-account-link #"docs.stripe.com"]]))
+
+(deftest create-account-link-request-test
+  (testing "create-account-link calls request correctly"
+    (h/check-request-calls
+     [{:api-fn v2-account-links/create-account-link
+       :args [{:account "acct_123" :use_case {:type "account_onboarding"}} {}]
+       :method :post
+       :endpoint "/v2/core/account_links"
+       :params {:account "acct_123" :use_case {:type "account_onboarding"}}
+       :opts {}}
+      ;; 2-arity defaults opts to {}
+      {:api-fn v2-account-links/create-account-link
+       :args [{:account "acct_123" :use_case {:type "account_onboarding"}}]
+       :method :post
+       :endpoint "/v2/core/account_links"
+       :params {:account "acct_123" :use_case {:type "account_onboarding"}}
+       :opts {}}])))

--- a/test/stripe_clojure/unit/v2/core/account_tokens_test.clj
+++ b/test/stripe_clojure/unit/v2/core/account_tokens_test.clj
@@ -1,0 +1,58 @@
+(ns stripe-clojure.unit.v2.core.account-tokens-test
+  (:require [clojure.test :refer [deftest testing]]
+            [stripe-clojure.unit.test-helpers :as h]
+            [stripe-clojure.v2.core.account-tokens :as v2-account-tokens]
+            [stripe-clojure.config :as config]))
+
+(deftest endpoint-configuration-test
+  (h/check-endpoint config/stripe-v2-endpoints :v2-core-account-tokens "/v2/core/account_tokens"))
+
+(deftest function-existence-test
+  (testing "all account token functions exist"
+    (h/check-functions-exist
+     [#'v2-account-tokens/create-account-token
+      #'v2-account-tokens/retrieve-account-token])))
+
+(deftest function-arities-test
+  (h/check-function-arities
+   [[#'v2-account-tokens/create-account-token #{2 3}]
+    [#'v2-account-tokens/retrieve-account-token #{2 3}]]))
+
+(deftest docstrings-test
+  (h/check-docstrings
+   [[#'v2-account-tokens/create-account-token #"docs.stripe.com" #"(?i)token"]
+    [#'v2-account-tokens/retrieve-account-token #"docs.stripe.com" #"(?i)token"]]))
+
+(deftest create-account-token-request-test
+  (testing "create-account-token calls request correctly"
+    (h/check-request-calls
+     [{:api-fn v2-account-tokens/create-account-token
+       :args [{:display_name "My Business"} {:idempotency-key "key_1"}]
+       :method :post
+       :endpoint "/v2/core/account_tokens"
+       :params {:display_name "My Business"}
+       :opts {:idempotency-key "key_1"}}
+      ;; 2-arity defaults opts to {}
+      {:api-fn v2-account-tokens/create-account-token
+       :args [{:display_name "My Business"}]
+       :method :post
+       :endpoint "/v2/core/account_tokens"
+       :params {:display_name "My Business"}
+       :opts {}}])))
+
+(deftest retrieve-account-token-request-test
+  (testing "retrieve-account-token calls request correctly"
+    (h/check-request-calls
+     [{:api-fn v2-account-tokens/retrieve-account-token
+       :args ["actok_123" {}]
+       :method :get
+       :endpoint "/v2/core/account_tokens/actok_123"
+       :params {}
+       :opts {}}
+      ;; 2-arity defaults opts to {}
+      {:api-fn v2-account-tokens/retrieve-account-token
+       :args ["actok_123"]
+       :method :get
+       :endpoint "/v2/core/account_tokens/actok_123"
+       :params {}
+       :opts {}}])))


### PR DESCRIPTION
  Summary                                                                                                                                                                              

  - Bump Stripe API version from 2026-01-28.clover to 2026-04-22.dahlia                                                                                                                  
  - Add 6 new endpoints from the latest OpenAPI spec (4 v1, 2 v2)
  - Fix nil opts handling in make-request to prevent validation errors                                                                                                                   
  - Fix per-request performance overhead in schema validation and event timing                                                                                                         
                                                                                                                                                                                         
  Changes                                                                                                                                                                              
                                                                                                                                                                                         
  New v1 endpoints                                                                                                                                                                     

  - issuing/settlements — retrieve, update                                                                                                                                               
  - radar/payment_evaluations — create
  - sigma/saved_queries — update                                                                                                                                                         
  - terminal/refunds — create                                                                                                                                                          
                                                                                                                                                                                         
  New v2 endpoints
                                                                                                                                                                                         
  - core/account_links — create                                                                                                                                                        
  - core/account_tokens — create, retrieve

  Bug fixes

  - Nil opts coercion: make-request now coerces nil opts to {} before validation, preventing ExceptionInfo when callers pass nil explicitly                                              
  - Double me/humanize: Validation error path now calls me/humanize once instead of twice
  - Inconsistent clock read: Response event emitter now captures System/currentTimeMillis once for both end-time and elapsed                                                             
                                                                                                                                                                                         
  Performance                                                                                                                                                                            
                                                                                                                                                                                         
  - Compiled Malli validator: Schema validation uses a pre-compiled m/validator on the hot path instead of m/explain per request. Full m/explain only runs on the error path.   